### PR TITLE
Implementing DB authentication needed on Heroku

### DIFF
--- a/src/db_utils.py
+++ b/src/db_utils.py
@@ -10,6 +10,12 @@ def get_database():
     connection = pymongo.MongoClient(os.environ.get("MONGODB_URI"))
     db = connection[DB_NAME]
 
+    MONGODB_USER = os.environ.get("MONGODB_USER", None)
+    MONGODB_PASS = os.environ.get("MONGODB_PASS", None)
+
+    if MONGODB_USER and MONGODB_PASS:
+        db.authenticate(MONGODB_USER, MONGODB_PASS)
+
     return db
 
 


### PR DESCRIPTION
Despite using the MongoDB URI provided by the Heroku add-on, which contains username and password of the user that will connect to the DB, Heroku requires us to authenticate or otherwise raises an `OperationalError` exception