### PR TITLE
#5 Reducing job waiting time

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -41,4 +41,4 @@ initialize_notifier()
 
 while True:
     schedule.run_pending()
-    time.sleep(600)
+    time.sleep(60)


### PR DESCRIPTION
Reducing time to wait between checking if the job should be executed from 10 to 1 minutes, as specified on issue #5 