### PR TITLE
Increasing the job execution frequency

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -36,9 +36,7 @@ def execute_notifier():
 
 
 # Setting the task to run periodically
-# ABOUT: The announcements get posted (generally) at 9:00 AM GMT+2 time. As schedule (or the Heroku server) uses
-# UTC time, this translates to 7:00 AM UTC
-schedule.every().day.at("7:00").do(execute_notifier)
+schedule.every().hour().do(execute_notifier)
 
 # Setting all announcements to posted on init
 initialize_notifier()


### PR DESCRIPTION
## What
We want to increase the frequency at which the announcements get posted to Reddit

## Why
Currently, the bot checks for new announcements every day at 7:00 AM UTC. This is the time when the day changes in-game, and therefore when most of the announcements get posted to present new events or deals. With this schedule, we'll be able to post most of the announcements within a few seconds of its creation. However, the problem with this approach is that there's a huge amount of time (24h) between two checks. This implies that an announcement can get posted with a 24-hour delay, which isn't by any means acceptable. 

## How
In order to solve this problem, we'll check for new announcements every hour instead of once a day. Although this will imply that most of the times where we check there won't be any new announcement, this will let us post every announcement with a very small delay. 