### PR TITLE
Reducing wait time

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -36,11 +36,11 @@ def execute_notifier():
 
 
 # Setting the task to run periodically
-schedule.every().hour.at(':00').do(execute_notifier)
+schedule.every().hour.at(':02').do(execute_notifier)
 
 # Setting all announcements to posted on init
 initialize_notifier()
 
 while True:
     schedule.run_pending()
-    time.sleep(60)
+    time.sleep(50)


### PR DESCRIPTION
### What?
We want to reduce the wait time between job execution

### Why? 
We've detected that sometimes the announcements get posted an hour later than expected. We don't want this to happen, as an hour late is not an acceptable delay. 

### How?
We've set `schedule` to execute the main routine every hour at `:02` minutes instead of exactly at ':00', to avoid not getting results if there's a small time difference between our server and the one where the announcements get posted. 

Also, we've set the program to sleep 50 seconds instead of 60 between each pending jobs check, so we make sure that we won't skip any minute. 