### PR TITLE
Adapt bot functionality to new subreddit

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -5,7 +5,5 @@ BOT_USER_AGENT = "KHUX_notice_bot by /u/Pawah"
 BOT_USERNAME = "khux_notice_bot"
 
 SUBREDDIT_TO_USE = "test"  # Starting with /r/test subreddit
-BOT_COMMENT = """Beeeeep bop. I'm a bot! I post SENA's announcements to /r/KingdomHearts.
-              If you want to know more about me, you can see my code on [Github](https://github.com/AlexGascon/KHUX-announcements-notifier) or contact my creator [/u/Pawah](https://www.reddit.com/user/pawah)"""
 
 DB_POSTED_KEY = "posted"

--- a/src/reddit.py
+++ b/src/reddit.py
@@ -37,6 +37,11 @@ def post_announcement(announcement):
         print("Posted announcement {}".format(announcement))
         
         if submission:
+            BOT_COMMENT = "Beeeeep bop. I'm a bot! I post SENA's announcements to /r/" + os.environ.get("SUBREDDIT") + \
+                          "\nIf you want to know more about me, you can see my code on " + \
+                          "[Github](https://github.com/AlexGascon/KHUX-announcements-notifier) or contact " + \
+                          "my creator [/u/Pawah](https://www.reddit.com/user/pawah)"
+
             comment_in_submission(submission)
 
         return submission

--- a/src/reddit.py
+++ b/src/reddit.py
@@ -27,7 +27,7 @@ def post_announcement(announcement):
     subreddit = get_subreddit()
 
     # Preparing the submission
-    title = "[KHUX] {title}".format(title=announcement.title)
+    title = "[News] {title}".format(title=announcement.title)
     url = announcement.url
 
     # Submitting


### PR DESCRIPTION
### What?
Due to changes in the /r/KingdomHearts rules, the information related to KHUX won't be posted there anymore, but on /r/KHUX instead. Therefore, there are some changes we need to make to the bot to adapt it to the new subreddit. 

### How
The subreddit change itself doesn't require any line of code, as we specify it through an environment variable, and therefore the changes in this PR don't affect that part. However, there are other changes we need to make. 

On the one hand, we don't have to prepend the `[KHUX]` tag to the submission title, as every post in the new subreddit is related to Union X. We'll change it to `[News]` instead.

On the other hand, we have to change the comment that the bot posts after each submission. The subreddit on the comment body was hardcoded, and now we've changed it to read from the ENV var instead. 

