### PR TITLE
Adapting bot to new subreddit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
-KHUX-announcements-notifier
+# KHUX Announcements Notifier
+![KHUX-Banner](http://cdn.tigthai.com/imguploads/201703/11/08308610014891972476806_Kingdom-Hearts-Union-thumb.jpg)
+
+KHUX Announcements Notifier is a Reddit bot that automatically posts to the /r/KingdomHearts subreddit the official in-game announcements made on [Kingdom Hearts Union Cross](http://www.kingdomhearts.com/unionx/us/). 

--- a/src/main.py
+++ b/src/main.py
@@ -36,11 +36,11 @@ def execute_notifier():
 
 
 # Setting the task to run periodically
-schedule.every().hour.at(':00').do(execute_notifier)
+schedule.every().hour.at(':02').do(execute_notifier)
 
 # Setting all announcements to posted on init
 initialize_notifier()
 
 while True:
     schedule.run_pending()
-    time.sleep(60)
+    time.sleep(50)


### PR DESCRIPTION
### What?
Due to changes in the /r/KingdomHearts rules, the information related to KHUX won't be posted there anymore, but on /r/KHUX instead. Therefore, there are some changes we need to make to the bot to adapt it to the new subreddit. 

### How
The subreddit change itself doesn't require any line of code, as we specify it through an environment variable, and therefore the changes in this PR don't affect that part. However, there are other changes we need to make. 

On the one hand, we don't have to prepend the `[KHUX]` tag to the submission title, as every post in the new subreddit is related to Union X. We'll change it to `[News]` instead.

On the other hand, we have to change the comment that the bot posts after each submission. The subreddit on the comment body was hardcoded, and now we've changed it to read from the ENV var instead. 

