### PR TITLE
Throwing an Exception if link has been posted

### DIFF
--- a/src/reddit.py
+++ b/src/reddit.py
@@ -34,12 +34,12 @@ def post_announcement(announcement):
 
     # Submitting
     try:
-        submission = subreddit.submit(title=title, url=url)
+        submission = subreddit.submit(title=title, url=url, resubmit=False)
         if submission:
             comment_in_submission(submission)
 
     except praw.exceptions.APIException as e:
-        print ("API RATE LIMIT ERROR: " + e.message)
+        print ("API EXCEPTION: " + e.message)
 
     except Exception as e:
         print ("EXCEPTION: " + e.message)


### PR DESCRIPTION
## What?
We want to avoid posting announcements twice or posting announcements that have already been submitted. 

## How?
The `Subreddit.submit` method has a parameter, `resubmit`, that is very helpful in this specific context. If it's set to `False` it avoids an URL to be submitted more than once in the same subreddit. 

When `resubmit=False` an APIException is thrown if we try to resubmit a link. As this exception is the same one that gets thrown when we hit the API rate limit (what is quite comment if we post to a new subreddit), we need to refactor the `except` clause to throw a more generic message.