### PR TITLE
Fix - Parsing announcements with unicode titles

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -3,6 +3,7 @@ import time
 
 from src.constants import ANNOUNCEMENT_URL
 from src.db_utils import insert_announcements, get_unposted_announcements, mark_announcement_as_posted
+from src.models import AnnouncementFactory
 from src.parser import parse_announcements
 from src.reddit import post_announcement
 from src.decorators import logger
@@ -12,7 +13,9 @@ from src.decorators import logger
 def parse_and_insert():
     # Insert announcements into DB
     url = ANNOUNCEMENT_URL
-    announcements = parse_announcements(url)
+    html_announcements = parse_announcements(url)
+    announcements = [AnnouncementFactory.announcement(html) for html in html_announcements]
+
     insert_announcements(announcements)
 
 

--- a/src/models.py
+++ b/src/models.py
@@ -1,4 +1,5 @@
 from src.constants import BASE_URL
+from src.parser import parse_announcement_title
 
 
 class Announcement:
@@ -47,12 +48,15 @@ class AnnouncementFactory:
     def announcement(cls, html_announcement):
         """Creates an Announcement object given its HTML content"""
 
-        title = html_announcement.a.text
         # The href has the form "detail/<id_number>". We just want the number
         href = html_announcement.a['href']
         announcement_id = href.split("/")[1]
 
-        return Announcement(title=title, announcement_id=announcement_id)
+        announcement = Announcement(title="", announcement_id=announcement_id)
+        title = parse_announcement_title(announcement.url)
+        announcement.title = title
+
+        return announcement
 
     @classmethod
     def from_mongo(cls, mongo_announcement):

--- a/src/parser.py
+++ b/src/parser.py
@@ -41,6 +41,6 @@ def parse_announcement_title(url):
     # Processing it with BeautifulSoup
     soup = BeautifulSoup(html_text, "html.parser")
 
-    title = soup.find('span', {'class': 'subject'})
+    title = soup.find('span', class_='subject'})
 
     return title.inner_html

--- a/src/parser.py
+++ b/src/parser.py
@@ -36,4 +36,4 @@ def parse_announcement_title(url):
 
     title = soup.find('span', class_='subject')
 
-    return title.inner_html
+    return str(title.text)

--- a/src/parser.py
+++ b/src/parser.py
@@ -11,6 +11,7 @@ from bs4 import BeautifulSoup
 from src.models import AnnouncementFactory
 from src.decorators import logger
 
+
 @logger
 def parse_announcements(url):
     """Extracts the announcements from the specified URL"""
@@ -31,3 +32,15 @@ def parse_announcements(url):
             announcements.append(announcement)
 
     return announcements
+
+
+def parse_announcement_title(url):
+
+    # Getting HTML content
+    html_text = urlopen(url).read()
+    # Processing it with BeautifulSoup
+    soup = BeautifulSoup(html_text, "html.parser")
+
+    title = soup.find('span', {'class': 'subject'})
+
+    return title.inner_html

--- a/src/parser.py
+++ b/src/parser.py
@@ -41,6 +41,6 @@ def parse_announcement_title(url):
     # Processing it with BeautifulSoup
     soup = BeautifulSoup(html_text, "html.parser")
 
-    title = soup.find('span', class_='subject'})
+    title = soup.find('span', class_='subject')
 
     return title.inner_html

--- a/src/parser.py
+++ b/src/parser.py
@@ -8,7 +8,6 @@ except ImportError:
 
 from bs4 import BeautifulSoup
 
-from src.models import AnnouncementFactory
 from src.decorators import logger
 
 
@@ -23,15 +22,9 @@ def parse_announcements(url):
     soup = BeautifulSoup(html_text, "html.parser")
 
     # Getting all the announcements and adding them to an array
-    list_announcements = soup.find_all('li')
-    announcements = []
-    for html_announcement in list_announcements:
-        announcement = AnnouncementFactory.announcement(html_announcement)
-        # We'll only append it to the Announcements array if the string is ascii
-        if announcement.is_ascii():
-            announcements.append(announcement)
+    html_announcements = soup.find_all('li')
 
-    return announcements
+    return html_announcements
 
 
 def parse_announcement_title(url):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2,6 +2,7 @@ import unittest
 from bs4 import BeautifulSoup
 
 from src.models import AnnouncementFactory, Announcement
+from src.parser import parse_announcement_title
 
 
 class TestModels(unittest.TestCase):
@@ -56,6 +57,14 @@ class TestModels(unittest.TestCase):
         reconverted_announcement = (AnnouncementFactory.from_mongo(self.mongoannouncement)).to_mongo()
         assert self.mongoannouncement["_id"] == reconverted_announcement["_id"]
         assert self.mongoannouncement["title"] == reconverted_announcement["title"]
+
+
+class TestParser(unittest.TestCase):
+
+    def test_parse_title(self):
+        url = 'http://api.sp.kingdomhearts.com/information/detail/37207'
+        self.assertEqual(parse_announcement_title(url), "Newcomer's and Top-Drawer Deals!")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2,7 +2,6 @@ import unittest
 from bs4 import BeautifulSoup
 
 from src.models import AnnouncementFactory, Announcement
-from src.parser import parse_announcement_title
 
 
 class TestModels(unittest.TestCase):
@@ -63,7 +62,7 @@ class TestParser(unittest.TestCase):
 
     def test_parse_title(self):
         url = 'http://api.sp.kingdomhearts.com/information/detail/37207'
-        self.assertEqual(parse_announcement_title(url), "Newcomer's and Top-Drawer Deals!")
+        self.assertEqual(AnnouncementFactory.parse_announcement_title(url), "Newcomer's and Top-Drawer Deals!")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Where?
**Issues:** #18 

### What?
Currently, a lot of announcements are not getting posted due to them containing the Unicode character ..., used when the title is longer than a certain amount of chars. AnnouncementFactory doesn't parse it correctly, or can't operate with it as expected, and therefore it simply ignores the announcements.

We fix that problem with this PR. 

### How?
Instead of obtaining the announcement title from the Announcements list page, we will now obtain them directly from inside the notice. There there isn't a character limitation, and therefore we won't find the ellipsis symbol no matter how long the title is. 

This doesn't completely fixes the Unicode problem, but it fixes most of the cases where it appeared. 