### PR TITLE
Including the announcement URL in the combined submission body

### DIFF
--- a/src/helpers.py
+++ b/src/helpers.py
@@ -1,0 +1,3 @@
+def format_announcement_for_combined_post(announcement):
+    return ("## " + announcement.title + "\n" +
+            "[Link to the " + announcement.title + " announcement](" + announcement.url + ") \n")

--- a/src/reddit.py
+++ b/src/reddit.py
@@ -61,7 +61,7 @@ def combine_announcements_post(announcements):
         # Preparing the submission
         title = "[News] " + ", ".join(announcement.title for announcement in announcements[:2]) + " and more!"
         separator = "\n--------------------------------------------------------\n"
-        body = separator.join(announcement.title for announcement in announcements)
+        body = separator.join(announcement.title + "\n" + announcement.url for announcement in announcements)
 
         submission = subreddit.submit(title=title, selftext=body)
         if submission:

--- a/src/reddit.py
+++ b/src/reddit.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 
 import praw
@@ -5,6 +6,7 @@ import praw
 from src.constants import BOT_USER_AGENT, BOT_USERNAME
 from src.db_utils import mark_announcement_as_posted
 from src.decorators import logger
+from src.helpers import format_announcement_for_combined_post
 
 
 @logger
@@ -60,8 +62,9 @@ def combine_announcements_post(announcements):
 
         # Preparing the submission
         title = "[News] " + ", ".join(announcement.title for announcement in announcements[:2]) + " and more!"
-        separator = "\n--------------------------------------------------------\n"
-        body = separator.join(announcement.title + "\n" + announcement.url for announcement in announcements)
+        separator = "\n"
+        body = "Here are SENA's announcements for " + datetime.datetime.today().strftime("%A %B %-d %Y") + "!\n"
+        body += separator.join(format_announcement_for_combined_post(announcement) for announcement in announcements)
 
         submission = subreddit.submit(title=title, selftext=body)
         if submission:


### PR DESCRIPTION
### What?
Recently, we introduced a change that allowed us to combine several announcements in a single submission. This will reduce the amount of post in the subreddit on those days where there are a lot of news (for example, when we get a new update)

However, we forgot to introduce the announcement URL in the combined post. This will have caused the announcements to contain only the title, which gives almost no useful information. On this PR, we intend to fix that problem

### How?
On the generator that generates submission's body, we've added a small text presenting the announcements for that day, and we list the title and the URL for each announcement

### Screenshots
![image](https://user-images.githubusercontent.com/2151412/41003194-6be4d12e-6916-11e8-8b0e-6d3c7fa2fa89.png)
