### PR TITLE
Fixing parse_title test

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2,6 +2,7 @@ import unittest
 from bs4 import BeautifulSoup
 
 from src.models import AnnouncementFactory, Announcement
+from src.parser import parse_announcement_title
 
 
 class TestModels(unittest.TestCase):
@@ -61,8 +62,8 @@ class TestModels(unittest.TestCase):
 class TestParser(unittest.TestCase):
 
     def test_parse_title(self):
-        url = 'http://api.sp.kingdomhearts.com/information/detail/37207'
-        self.assertEqual(AnnouncementFactory.parse_announcement_title(url), "Newcomer's and Top-Drawer Deals!")
+        url = 'http://api.sp.kingdomhearts.com/information/detail/40171'
+        self.assertEqual(parse_announcement_title(url), '0 AP Campaign!')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This test was trying to execute the `AnnouncementFactory.parse_announcement_title`. 

However, this method doesn't actually exist: the method is part of the `parser` module of the app, and isn't linked to any particular class.