### PR TITLE
Migrating from mLab to MongoDB Atlas

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,12 @@
+-i https://pypi.org/simple
 beautifulsoup4==4.6.0
 certifi==2017.7.27.1
 chardet==3.0.4
+dnspython==1.16.0
 idna==2.6
 praw==5.1.0
 prawcore==0.12.0
-pymongo==3.5.1
+pymongo[srv]==3.10.1
 requests==2.18.4
 schedule==0.4.3
 update-checker==0.16

--- a/src/db_utils.py
+++ b/src/db_utils.py
@@ -8,14 +8,8 @@ from src.decorators import logger
 @logger
 def get_database():
     """Connects to the DB and returns it"""
-    connection = pymongo.MongoClient(os.environ.get("MONGODB_URI"))
-    db = connection[os.environ.get("MONGODB_DATABASE")]
-
-    MONGODB_USER = os.environ.get("MONGODB_USER", None)
-    MONGODB_PASS = os.environ.get("MONGODB_PASS", None)
-
-    if MONGODB_USER and MONGODB_PASS:
-        db.authenticate(MONGODB_USER, MONGODB_PASS)
+    connection = pymongo.MongoClient(os.environ.get("DB_URI"))
+    db = connection[os.environ.get("DB_DATABASE")]
 
     return db
 
@@ -23,7 +17,7 @@ def get_database():
 def get_collection():
     """Gets the collection we'll use to store the information and returns it"""
     db = get_database()
-    collection = db[os.environ.get("MONGODB_COLLECTION")]
+    collection = db[os.environ.get("DB_COLLECTION")]
 
     return collection
 


### PR DESCRIPTION
## Description
mLab was acquired by MongoDB a while ago, and as part of that process they are discontinuing their Heroku add-on and encouraging their users to migrate to MongoDB Atlas ([announcement link]). They offer a [migration guide](https://docs.mlab.com/how-to-migrate-sandbox-heroku-addons-to-atlas/), which is pretty straightforward to follow and can be executed mostly via web UI. This PR contains the only code-specific changes required to complete the process

## Technical details
From the technical perspective, there are only two changes required in the project:
1) Switching to a different set of environment variables to start using MongoDB Atlas instead of mLab. The old envvars still keep the mLab configuration in case we ever need to rollback
2) Dropping the explicit authentication. The MongoDB URI we are using now contains the username and password, so the client is authenticated by default

## Testing
As none of the tests in the project cover MongoDB interactions, they have been tested manually, by replicating the statements executed in the project in a Python Shell that replicates this environment. All these operations have completed successfully